### PR TITLE
 Ignore ghost effect in "touching" tests

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -645,7 +645,7 @@ export default class Renderer {
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    this._renderLayers(spr);
+    this._renderLayers(new Set([spr]));
 
     const hoveredPixel = new Uint8Array(4);
     const cx = this._collisionBuffer.width / 2;

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -204,11 +204,7 @@ export default class Renderer {
 
     // Stage
     if (shouldIncludeLayer(this.project.stage)) {
-      this.renderSprite(
-        this.project.stage,
-        options.drawMode,
-        options.beforeRenderingSkin
-      );
+      this.renderSprite(this.project.stage, options);
     }
 
     // Pen layer
@@ -236,12 +232,7 @@ export default class Renderer {
     for (const sprite of this.project.spritesAndClones) {
       // Stage doesn't have "visible" defined, so check if it's strictly false
       if (shouldIncludeLayer(sprite) && sprite.visible !== false) {
-        this.renderSprite(
-          sprite,
-          options.drawMode,
-          options.beforeRenderingSkin,
-          options.renderSpeechBubbles
-        );
+        this.renderSprite(sprite, options);
       }
     }
   }
@@ -419,27 +410,32 @@ export default class Renderer {
     return m;
   }
 
-  renderSprite(sprite, drawMode, beforeRenderingSkin, renderBubble = true) {
+  renderSprite(sprite, options) {
     const spriteScale = Object.prototype.hasOwnProperty.call(sprite, "size")
       ? sprite.size / 100
       : 1;
 
     this._setSkinUniforms(
       this._skinCache.getSkin(sprite.costume),
-      drawMode,
+      options.drawMode,
       this._calculateSpriteMatrix(sprite),
       spriteScale,
       sprite.effects
     );
-    if (typeof beforeRenderingSkin === "function") beforeRenderingSkin();
+    if (typeof options.beforeRenderingSkin === "function")
+      options.beforeRenderingSkin();
     this.gl.drawArrays(this.gl.TRIANGLES, 0, 6);
 
-    if (renderBubble && sprite._speechBubble && sprite._speechBubble.text) {
+    if (
+      options.renderSpeechBubbles &&
+      sprite._speechBubble &&
+      sprite._speechBubble.text
+    ) {
       const speechBubbleSkin = this._skinCache.getSkin(sprite._speechBubble);
 
       this._setSkinUniforms(
         speechBubbleSkin,
-        drawMode,
+        options.drawMode,
         this._calculateSpeechBubbleMatrix(sprite, speechBubbleSkin),
         1,
         null

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -422,8 +422,11 @@ export default class Renderer {
       spriteScale,
       sprite.effects
     );
-    if (typeof options.beforeRenderingSkin === "function")
-      options.beforeRenderingSkin();
+    if (Array.isArray(options.colorMask))
+      this.gl.uniform4fv(
+        this._currentShader.uniform("u_colorMask"),
+        options.colorMask
+      );
     this.gl.drawArrays(this.gl.TRIANGLES, 0, 6);
 
     if (
@@ -479,12 +482,7 @@ export default class Renderer {
     // If we mask in the color (for e.g. "color is touching color"),
     // we need to pass that in as a uniform as well.
     if (colorMask) {
-      opts.beforeRenderingSkin = (skin, shader) => {
-        gl.uniform4fv(
-          shader.uniform("u_colorMask"),
-          colorMask.toRGBANormalized()
-        );
-      };
+      opts.colorMask = colorMask.toRGBANormalized();
       opts.drawMode = ShaderManager.DrawModes.COLOR_MASK;
     }
     this._renderLayers(new Set([spr]), opts);

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -2,7 +2,7 @@ import Color from "./Color.js";
 import Trigger from "./Trigger.js";
 import Sound, { EffectChain, AudioEffectMap } from "./Sound.js";
 
-import effectNames from "./renderer/effectNames.js";
+import { effectNames } from "./renderer/effectInfo.js";
 // This is a wrapper to allow the enabled effects in a sprite to be used as a Map key.
 // By setting an effect, the bitmask is updated as well.
 // This allows the bitmask to be used to uniquely identify a set of enabled effects.

--- a/src/renderer/ShaderManager.js
+++ b/src/renderer/ShaderManager.js
@@ -119,6 +119,11 @@ class ShaderManager {
       gl.attachShader(program, fragShader);
       gl.linkProgram(program);
 
+      if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        const info = gl.getProgramInfoLog(program);
+        throw new Error("Could not compile WebGL program. \n" + info);
+      }
+
       const shader = new Shader(gl, program);
       shaderMap.set(effectBitmask, shader);
       return shader;

--- a/src/renderer/ShaderManager.js
+++ b/src/renderer/ShaderManager.js
@@ -1,5 +1,5 @@
 import { SpriteShader, PenLineShader } from "./Shaders.js";
-import effectNames from "./effectNames.js";
+import { effectNames, effectBitmasks } from "./effectInfo.js";
 
 // Everything contained in a shader. It contains both the program, and the locations of the shader inputs.
 class Shader {
@@ -98,8 +98,9 @@ class ShaderManager {
 
       // Add #defines for each enabled effect.
       for (let i = 0; i < effectNames.length; i++) {
-        if ((effectBitmask & (1 << i)) !== 0) {
-          define += `#define EFFECT_${effectNames[i]}\n`;
+        const effectName = effectNames[i];
+        if ((effectBitmask & effectBitmasks[effectName]) !== 0) {
+          define += `#define EFFECT_${effectName}\n`;
         }
       }
 

--- a/src/renderer/effectInfo.js
+++ b/src/renderer/effectInfo.js
@@ -1,5 +1,5 @@
 // This file exists to specify a mapping from numeric indices to effect names in all places that require it.
-export default [
+const effectNames = [
   "color",
   "fisheye",
   "whirl",
@@ -8,3 +8,10 @@ export default [
   "brightness",
   "ghost"
 ];
+
+const effectBitmasks = {};
+for (let i = 0; i < effectNames.length; i++) {
+  effectBitmasks[effectNames[i]] = 1 << i;
+}
+
+export { effectNames, effectBitmasks };


### PR DESCRIPTION
Resolves #65

This includes a lot of other code cleanups for the renderer that make this a lot easier to implement.