### PR TITLE
Update pen line code to that used in scratch-render

### DIFF
--- a/src/renderer/Shaders.js
+++ b/src/renderer/Shaders.js
@@ -183,21 +183,61 @@ PenLineShader.vertex = `
 precision mediump float;
 
 attribute vec2 a_position;
+// The X and Y components of u_penPoints hold the first pen point. The Z and W components hold the difference between
+// the second pen point and the first. This is done because calculating the difference in the shader leads to floating-
+// point error when both points have large-ish coordinates.
 uniform vec4 u_penPoints;
 uniform vec2 u_penSkinSize;
 uniform float u_penSize;
+uniform float u_lineLength;
 
 varying vec2 v_texCoord;
 
-void main() {
-  float penRadius = u_penSize * 0.5;
-  vec2 topRight = floor(min(u_penPoints.xy, u_penPoints.zw) - penRadius);
-  vec2 bottomLeft = ceil(max(u_penPoints.xy, u_penPoints.zw) + penRadius);
-  vec2 penBounds = a_position * (bottomLeft - topRight) + topRight;
+// Add this to divisors to prevent division by 0, which results in NaNs propagating through calculations.
+// Smaller values can cause problems on some mobile devices.
+const float epsilon = 1e-3;
 
-  vec2 position = (penBounds / u_penSkinSize) * 2.0;
-  v_texCoord = penBounds;
-  gl_Position = vec4(position, 1.0, 1.0);
+void main() {
+  // Calculate a rotated ("tight") bounding box around the two pen points.
+  // Yes, we're doing this 6 times (once per vertex), but on actual GPU hardware,
+  // it's still faster than doing it in JS combined with the cost of uniformMatrix4fv.
+
+  // Expand line bounds by sqrt(2) / 2 each side-- this ensures that all antialiased pixels
+  // fall within the quad, even at a 45-degree diagonal
+  vec2 position = a_position;
+  float expandedRadius = (u_penSize * 0.5) + 1.4142135623730951;
+
+  // The X coordinate increases along the length of the line. It's 0 at the center of the origin point
+  // and is in pixel-space (so at n pixels along the line, its value is n).
+  v_texCoord.x = mix(0.0, u_lineLength + (expandedRadius * 2.0), a_position.x) - expandedRadius;
+  // The Y coordinate is perpendicular to the line. It's also in pixel-space.
+  v_texCoord.y = ((a_position.y - 0.5) * expandedRadius) + 0.5;
+
+  position.x *= u_lineLength + (2.0 * expandedRadius);
+  position.y *= 2.0 * expandedRadius;
+
+  // 1. Center around first pen point
+  position -= expandedRadius;
+
+  // 2. Rotate quad to line angle
+  vec2 pointDiff = u_penPoints.zw;
+  // Ensure line has a nonzero length so it's rendered properly
+  // As long as either component is nonzero, the line length will be nonzero
+  // If the line is zero-length, give it a bit of horizontal length
+  pointDiff.x = (abs(pointDiff.x) < epsilon && abs(pointDiff.y) < epsilon) ? epsilon : pointDiff.x;
+  // The 'normalized' vector holds rotational values equivalent to sine/cosine
+  // We're applying the standard rotation matrix formula to the position to rotate the quad to the line angle
+  // pointDiff can hold large values so we must divide by u_lineLength instead of calling GLSL's normalize function:
+  // https://asawicki.info/news_1596_watch_out_for_reduced_precision_normalizelength_in_opengl_es
+  vec2 normalized = pointDiff / max(u_lineLength, epsilon);
+  position = mat2(normalized.x, normalized.y, -normalized.y, normalized.x) * position;
+
+  // 3. Translate quad
+  position += u_penPoints.xy;
+
+  // 4. Apply view transform
+  position *= 2.0 / u_penSkinSize;
+  gl_Position = vec4(position, 0, 1);
 }
 `;
 
@@ -208,21 +248,27 @@ uniform sampler2D u_texture;
 uniform vec4 u_penPoints;
 uniform vec4 u_penColor;
 uniform float u_penSize;
+uniform float u_lineLength;
 varying vec2 v_texCoord;
 
 void main() {
   // Maaaaagic antialiased-line-with-round-caps shader.
-  // Adapted from Inigo Quilez' 2D distance function cheat sheet
-  // https://www.iquilezles.org/www/articles/distfunctions2d/distfunctions2d.htm
-  vec2 pa = v_texCoord - u_penPoints.xy, ba = u_penPoints.zw - u_penPoints.xy;
-  float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
 
-  float cappedLine = clamp((u_penSize + 1.0) * 0.5 - length(pa - ba*h), 0.0, 1.0);
+	// "along-the-lineness". This increases parallel to the line.
+	// It goes from negative before the start point, to 0.5 through the start to the end, then ramps up again
+	// past the end point.
+	float d = ((v_texCoord.x - clamp(v_texCoord.x, 0.0, u_lineLength)) * 0.5) + 0.5;
 
-  // Premultiply pen color by its alpha
-  vec4 premul = vec4(vec3(u_penColor.rgb * u_penColor.a), u_penColor.a);
-
-  gl_FragColor = premul * cappedLine;
+	// Distance from (0.5, 0.5) to (d, the perpendicular coordinate). When we're in the middle of the line,
+	// d will be 0.5, so the distance will be 0 at points close to the line and will grow at points further from it.
+	// For the "caps", d will ramp down/up, giving us rounding.
+	// See https://www.youtube.com/watch?v=PMltMdi1Wzg for a rough outline of the technique used to round the lines.
+	float line = distance(vec2(0.5), vec2(d, v_texCoord.y)) * 2.0;
+	// Expand out the line by its thickness.
+	line -= ((u_penSize - 1.0) * 0.5);
+	// Because "distance to the center of the line" decreases the closer we get to the line, but we want more opacity
+	// the closer we are to the line, invert it.
+	gl_FragColor = u_penColor * clamp(1.0 - line, 0.0, 1.0);
 }
 `;
 


### PR DESCRIPTION
This code is a bit ugly, but necessary to work around really bad floating-point precision in some mobile GPUs.

This was taken from scratch-render, but given that it's entirely my code, I don't expect any licensing issues.