### PR TITLE
Return false if sprite collision is offscreen

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -541,7 +541,7 @@ export default class Renderer {
       cy
     );
 
-    if (collisionBox.width === 0 || collisionBox.height === 0) return;
+    if (collisionBox.width === 0 || collisionBox.height === 0) return false;
 
     this._setFramebuffer(this._collisionBuffer);
     // Enable stencil testing then stencil in this sprite, which masks all further drawing to this sprite's area.


### PR DESCRIPTION
This seems to be an oversight--I was previously returning `undefined` if both sprites in a "touching" test were completely offscreen. Now it returns `false` as it should.