### PR TITLE
Make shader attribute/uniform locations accessible via object properties

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -129,7 +129,7 @@ export default class Renderer {
 
       // These attributes and uniforms don't ever change, but must be set whenever a new shader program is used.
 
-      const attribLocation = shader.attrib("a_position");
+      const attribLocation = shader.attribs.a_position;
       gl.enableVertexAttribArray(attribLocation);
       // Bind the 'a_position' vertex attribute to the current contents of `gl.ARRAY_BUFFER`, which in this case
       // is a quadrilateral (as buffered earlier).
@@ -243,7 +243,7 @@ export default class Renderer {
       // The shader is passed things in "Scratch-space" (-240, 240) and (-180, 180).
       // This tells it those dimensions so it can convert them to OpenGL "clip-space" (-1, 1).
       this.gl.uniform2f(
-        this._currentShader.uniform("u_stageSize"),
+        this._currentShader.uniforms.u_stageSize,
         this.project.stage.width,
         this.project.stage.height
       );
@@ -327,23 +327,23 @@ export default class Renderer {
     if (typeof effectMask === "number") effectBitmask &= effectMask;
     const shader = this._shaderManager.getShader(drawMode, effectBitmask);
     this._setShader(shader);
-    gl.uniformMatrix3fv(shader.uniform("u_transform"), false, matrix);
+    gl.uniformMatrix3fv(shader.uniforms.u_transform, false, matrix);
 
     if (effectBitmask !== 0) {
       for (const effect of Object.keys(effects._effectValues)) {
         const effectVal = effects._effectValues[effect];
         if (effectVal !== 0)
-          gl.uniform1f(shader.uniform(`u_${effect}`), effectVal);
+          gl.uniform1f(shader.uniforms[`u_${effect}`], effectVal);
       }
 
       // Pixelate effect needs the skin size
       if (effects._effectValues.pixelate !== 0)
-        gl.uniform2f(shader.uniform("u_skinSize"), skin.width, skin.height);
+        gl.uniform2f(shader.uniforms.u_skinSize, skin.width, skin.height);
     }
 
     gl.bindTexture(gl.TEXTURE_2D, skinTexture);
     // All textures are bound to texture unit 0, so that's where the texture sampler should point
-    gl.uniform1i(shader.uniform("u_texture"), 0);
+    gl.uniform1i(shader.uniforms.u_texture, 0);
   }
 
   // Calculate the transform matrix for a sprite.
@@ -427,7 +427,7 @@ export default class Renderer {
     );
     if (Array.isArray(options.colorMask))
       this.gl.uniform4fv(
-        this._currentShader.uniform("u_colorMask"),
+        this._currentShader.uniforms.u_colorMask,
         options.colorMask
       );
     this.gl.drawArrays(this.gl.TRIANGLES, 0, 6);

--- a/src/renderer/PenSkin.js
+++ b/src/renderer/PenSkin.js
@@ -47,7 +47,7 @@ export default class PenSkin extends Skin {
 
     // These uniforms only need to be set if the shader actually changed.
     if (shaderChanged) {
-      gl.uniform2f(shader.uniform("u_penSkinSize"), this.width, this.height);
+      gl.uniform2f(shader.uniforms.u_penSkinSize, this.width, this.height);
     }
 
     // Only set the pen color if it changed or the shader changed.
@@ -62,7 +62,7 @@ export default class PenSkin extends Skin {
     ) {
       this._lastPenState.color = penColor;
       gl.uniform4f(
-        shader.uniform("u_penColor"),
+        shader.uniforms.u_penColor,
         penColor[0] * penColor[3],
         penColor[1] * penColor[3],
         penColor[2] * penColor[3],
@@ -73,14 +73,14 @@ export default class PenSkin extends Skin {
     // Only set the pen size if it changed or the shader changed.
     if (shaderChanged || this._lastPenState.size !== size) {
       this._lastPenState.size = size;
-      gl.uniform1f(shader.uniform("u_penSize"), size);
+      gl.uniform1f(shader.uniforms.u_penSize, size);
     }
 
     const lineDiffX = pt2.x - pt1.x;
     const lineDiffY = pt2.y - pt1.y;
 
     gl.uniform4f(
-      shader.uniform("u_penPoints"),
+      shader.uniforms.u_penPoints,
       pt1.x,
       pt1.y,
       lineDiffX,
@@ -93,7 +93,7 @@ export default class PenSkin extends Skin {
     // Even GLSL's `length` function won't save us here:
     // https://asawicki.info/news_1596_watch_out_for_reduced_precision_normalizelength_in_opengl_es
     const lineLength = Math.sqrt(lineDiffX * lineDiffX + lineDiffY * lineDiffY);
-    gl.uniform1f(shader.uniform("u_lineLength"), lineLength);
+    gl.uniform1f(shader.uniforms.u_lineLength, lineLength);
 
     gl.drawArrays(gl.TRIANGLES, 0, 6);
   }

--- a/src/renderer/ShaderManager.js
+++ b/src/renderer/ShaderManager.js
@@ -6,19 +6,19 @@ class Shader {
   constructor(gl, program) {
     this.gl = gl;
     this.program = program;
-    this._uniformLocations = new Map();
-    this._attribLocations = new Map();
+    this.uniforms = {};
+    this.attribs = {};
 
+    // In order to pass a value into a shader as an attribute or uniform, you need to know its location.
+    // This maps the names of attributes and uniforms to their locations, accessible via the `uniforms` and `attribs`
+    // properties.
     const numActiveUniforms = gl.getProgramParameter(
       program,
       gl.ACTIVE_UNIFORMS
     );
     for (let i = 0; i < numActiveUniforms; i++) {
-      const uniformInfo = gl.getActiveUniform(program, i);
-      this._uniformLocations.set(
-        uniformInfo.name,
-        gl.getUniformLocation(program, uniformInfo.name)
-      );
+      const { name } = gl.getActiveUniform(program, i);
+      this.uniforms[name] = gl.getUniformLocation(program, name);
     }
 
     const numActiveAttributes = gl.getProgramParameter(
@@ -26,23 +26,9 @@ class Shader {
       gl.ACTIVE_ATTRIBUTES
     );
     for (let i = 0; i < numActiveAttributes; i++) {
-      const attribInfo = gl.getActiveAttrib(program, i);
-      this._attribLocations.set(
-        attribInfo.name,
-        gl.getAttribLocation(program, attribInfo.name)
-      );
+      const { name } = gl.getActiveAttrib(program, i);
+      this.attribs[name] = gl.getAttribLocation(program, name);
     }
-  }
-
-  // In order to pass a value into a shader as an attribute or uniform, you need to know its location.
-  // That's what these two functions do. You give them the name of an attribute or uniform,
-  // and they tell you where the attribute or uniform is located so you can specify its value.
-  attrib(attribName) {
-    return this._attribLocations.get(attribName);
-  }
-
-  uniform(uniformName) {
-    return this._uniformLocations.get(uniformName);
   }
 }
 

--- a/src/renderer/ShaderManager.js
+++ b/src/renderer/ShaderManager.js
@@ -37,6 +37,7 @@ class ShaderManager {
     this.renderer = renderer;
     this.gl = renderer.gl;
 
+    // We compile shaders on-demand. Create one shader cache per draw mode.
     this._shaderCache = {};
     for (const drawMode of Object.keys(ShaderManager.DrawModes)) {
       this._shaderCache[drawMode] = new Map();
@@ -60,6 +61,8 @@ class ShaderManager {
 
   getShader(drawMode, effectBitmask = 0) {
     const gl = this.gl;
+    // Each combination of enabled effects is compiled to a different shader, with only the needed effect code.
+    // Check if we've already compiled the shader with this set of enabled effects.
     const shaderMap = this._shaderCache[drawMode];
     if (shaderMap.has(effectBitmask)) {
       return shaderMap.get(effectBitmask);
@@ -118,12 +121,15 @@ class ShaderManager {
 }
 
 ShaderManager.DrawModes = {
+  // Used for drawing sprites normally
   DEFAULT: "DEFAULT",
-  PEN_LINE: "PEN_LINE",
+  // Used for "touching" tests. Discards transparent pixels.
   SILHOUETTE: "SILHOUETTE",
-  COLOR_MASK: "COLOR_MASK"
+  // Used for "color is touching color" tests. Only renders sprite colors which are close to the color passed in, and
+  // discards all pixels of a different color.
+  COLOR_MASK: "COLOR_MASK",
+  // Used for drawing pen lines.
+  PEN_LINE: "PEN_LINE"
 };
-
-// TODO: effects.
 
 export default ShaderManager;

--- a/src/renderer/Shaders.js
+++ b/src/renderer/Shaders.js
@@ -183,21 +183,61 @@ PenLineShader.vertex = `
 precision mediump float;
 
 attribute vec2 a_position;
+// The X and Y components of u_penPoints hold the first pen point. The Z and W components hold the difference between
+// the second pen point and the first. This is done because calculating the difference in the shader leads to floating-
+// point error when both points have large-ish coordinates.
 uniform vec4 u_penPoints;
 uniform vec2 u_penSkinSize;
 uniform float u_penSize;
+uniform float u_lineLength;
 
 varying vec2 v_texCoord;
 
-void main() {
-  float penRadius = u_penSize * 0.5;
-  vec2 topRight = floor(min(u_penPoints.xy, u_penPoints.zw) - penRadius);
-  vec2 bottomLeft = ceil(max(u_penPoints.xy, u_penPoints.zw) + penRadius);
-  vec2 penBounds = a_position * (bottomLeft - topRight) + topRight;
+// Add this to divisors to prevent division by 0, which results in NaNs propagating through calculations.
+// Smaller values can cause problems on some mobile devices.
+const float epsilon = 1e-3;
 
-  vec2 position = (penBounds / u_penSkinSize) * 2.0;
-  v_texCoord = penBounds;
-  gl_Position = vec4(position, 1.0, 1.0);
+void main() {
+  // Calculate a rotated ("tight") bounding box around the two pen points.
+  // Yes, we're doing this 6 times (once per vertex), but on actual GPU hardware,
+  // it's still faster than doing it in JS combined with the cost of uniformMatrix4fv.
+
+  // Expand line bounds by sqrt(2) / 2 each side-- this ensures that all antialiased pixels
+  // fall within the quad, even at a 45-degree diagonal
+  vec2 position = a_position;
+  float expandedRadius = (u_penSize * 0.5) + 1.4142135623730951;
+
+  // The X coordinate increases along the length of the line. It's 0 at the center of the origin point
+  // and is in pixel-space (so at n pixels along the line, its value is n).
+  v_texCoord.x = mix(0.0, u_lineLength + (expandedRadius * 2.0), a_position.x) - expandedRadius;
+  // The Y coordinate is perpendicular to the line. It's also in pixel-space.
+  v_texCoord.y = ((a_position.y - 0.5) * expandedRadius) + 0.5;
+
+  position.x *= u_lineLength + (2.0 * expandedRadius);
+  position.y *= 2.0 * expandedRadius;
+
+  // 1. Center around first pen point
+  position -= expandedRadius;
+
+  // 2. Rotate quad to line angle
+  vec2 pointDiff = u_penPoints.zw;
+  // Ensure line has a nonzero length so it's rendered properly
+  // As long as either component is nonzero, the line length will be nonzero
+  // If the line is zero-length, give it a bit of horizontal length
+  pointDiff.x = (abs(pointDiff.x) < epsilon && abs(pointDiff.y) < epsilon) ? epsilon : pointDiff.x;
+  // The 'normalized' vector holds rotational values equivalent to sine/cosine
+  // We're applying the standard rotation matrix formula to the position to rotate the quad to the line angle
+  // pointDiff can hold large values so we must divide by u_lineLength instead of calling GLSL's normalize function:
+  // https://asawicki.info/news_1596_watch_out_for_reduced_precision_normalizelength_in_opengl_es
+  vec2 normalized = pointDiff / max(u_lineLength, epsilon);
+  position = mat2(normalized.x, normalized.y, -normalized.y, normalized.x) * position;
+
+  // 3. Translate quad
+  position += u_penPoints.xy;
+
+  // 4. Apply view transform
+  position *= 2.0 / u_penSkinSize;
+  gl_Position = vec4(position, 0, 1);
 }
 `;
 
@@ -208,21 +248,27 @@ uniform sampler2D u_texture;
 uniform vec4 u_penPoints;
 uniform vec4 u_penColor;
 uniform float u_penSize;
+uniform float u_lineLength;
 varying vec2 v_texCoord;
 
 void main() {
   // Maaaaagic antialiased-line-with-round-caps shader.
-  // Adapted from Inigo Quilez' 2D distance function cheat sheet
-  // https://www.iquilezles.org/www/articles/distfunctions2d/distfunctions2d.htm
-  vec2 pa = v_texCoord - u_penPoints.xy, ba = u_penPoints.zw - u_penPoints.xy;
-  float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
 
-  float cappedLine = clamp((u_penSize + 1.0) * 0.5 - length(pa - ba*h), 0.0, 1.0);
+	// "along-the-lineness". This increases parallel to the line.
+	// It goes from negative before the start point, to 0.5 through the start to the end, then ramps up again
+	// past the end point.
+	float d = ((v_texCoord.x - clamp(v_texCoord.x, 0.0, u_lineLength)) * 0.5) + 0.5;
 
-  // Premultiply pen color by its alpha
-  vec4 premul = vec4(vec3(u_penColor.rgb * u_penColor.a), u_penColor.a);
-
-  gl_FragColor = premul * cappedLine;
+	// Distance from (0.5, 0.5) to (d, the perpendicular coordinate). When we're in the middle of the line,
+	// d will be 0.5, so the distance will be 0 at points close to the line and will grow at points further from it.
+	// For the "caps", d will ramp down/up, giving us rounding.
+	// See https://www.youtube.com/watch?v=PMltMdi1Wzg for a rough outline of the technique used to round the lines.
+	float line = distance(vec2(0.5), vec2(d, v_texCoord.y)) * 2.0;
+	// Expand out the line by its thickness.
+	line -= ((u_penSize - 1.0) * 0.5);
+	// Because "distance to the center of the line" decreases the closer we get to the line, but we want more opacity
+	// the closer we are to the line, invert it.
+	gl_FragColor = u_penColor * clamp(1.0 - line, 0.0, 1.0);
 }
 `;
 


### PR DESCRIPTION
This includes #88 because it touches some of the same code.

See the commit message for details on why I'm doing this--essentially, passing parameters (uniforms and attributes) into a shader requires knowing their location (numeric), and for ease of use, we map their names to those locations. Because we only do this mapping once, a `Map` (optimized for adding/removing elements often) is probably not the best choice.

I also commented `ShaderManager` a bit more so it's a tiny bit easier to understand--at some point, I want to go back and document the renderer code more.